### PR TITLE
feat(client): remove force wantDiagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ You need [clangd](https://clangd.github.io/installation.html) installed already,
 - `clangd.enabled`: enable `coc-clangd`, default `true`
 - `clangd.path`: path to `clangd` executable, default `clangd`
 - `clangd.arguments`: arguments for `clangd` server
-- `clangd.wantDiagnostics`: force diagnostics generation, default `false`
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -70,11 +70,6 @@
             "type": "string"
           },
           "description": "Arguments for clangd server"
-        },
-        "clangd.wantDiagnostics": {
-          "type": "boolean",
-          "default": false,
-          "description": "Force diagnostics generation"
         }
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,8 +17,4 @@ export class Config {
   get arguments() {
     return this.cfg.get<string[]>('arguments', []);
   }
-
-  get wantDiagnostics() {
-    return this.cfg.get('wantDiagnostics', false);
-  }
 }

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -62,13 +62,6 @@ export class Ctx {
       initializationOptions: { clangdFileStatus: true },
       outputChannel,
       middleware: {
-        didChange: params => {
-          if (this.config.wantDiagnostics) {
-            // @ts-ignore
-            params.wantDiagnostics = true;
-          }
-          client.sendNotification(DidChangeTextDocumentNotification.type.method, params); // eslint-disable-line
-        },
         handleDiagnostics: (uri: string, diagnostics: Diagnostic[], next: HandleDiagnosticsSignature) => {
           for (const diagnostic of diagnostics) {
             // @ts-ignore


### PR DESCRIPTION
clangd supports this extension for clients that need to selectively
enable/disable diagnostics on certain snapshots (e.g. in insert mode).

It's not really a sensible feature to expose to users directly.
I can't think of any scenario where a user would want to force it always on.