### PR TITLE
feat(suggest): enable dot-to-arrow fixes in clangd

### DIFF
--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -7,7 +7,7 @@ import { Config } from './config';
 class DiagnosticFeature implements StaticFeature {
   initialize() {}
   fillClientCapabilities(capabilities: any) {
-    let textDocument = capabilities.textDocument as TextDocumentClientCapabilities
+    const textDocument = capabilities.textDocument as TextDocumentClientCapabilities;
     // @ts-ignore: clangd extension
     textDocument.publishDiagnostics?.categorySupport = true;
     // @ts-ignore: clangd extension

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -7,10 +7,13 @@ import { Config } from './config';
 class DiagnosticFeature implements StaticFeature {
   initialize() {}
   fillClientCapabilities(capabilities: any) {
-    // @ts-ignore
-    (capabilities.textDocument as TextDocumentClientCapabilities).publishDiagnostics?.categorySupport = true;
-    // @ts-ignore
-    (capabilities.textDocument as TextDocumentClientCapabilities).publishDiagnostics?.codeActionsInline = true;
+    let textDocument = capabilities.textDocument as TextDocumentClientCapabilities
+    // @ts-ignore: clangd extension
+    textDocument.publishDiagnostics?.categorySupport = true;
+    // @ts-ignore: clangd extension
+    textDocument.publishDiagnostics?.codeActionsInline = true;
+    // @ts-ignore: clangd extension
+    textDocument.completion?.editsNearCursor = true;
   }
 }
 


### PR DESCRIPTION
The `editsNearCursor` capability tells clangd that the editor is smart
enough to handle additionalTextEdits that are near the cursor (LSP spec
says the editor doesn't have to be able to handle this).

This enables completions like:

```
struct S { int xxx; };
S *y;
y.x^ // 'xxx', also corrects . to ->
```