### PR TITLE
feat(diagnostics): remove diagnostic category

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You need [clangd](https://clangd.github.io/installation.html) installed already,
 - Switch between source/header, using command `:CocCommand clangd.switchSourceHeader`
 - File status monitor, shows on statusline
 - Force diagnostics generation, default `true`
-- Diagnostic categories & inline fixes
+- Diagnostic inline fixes
 - Symbol info under cursor, using command: `:CocCommand clangd.symbolInfo`
 
 ## Configurations

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -9,8 +9,6 @@ class ClangdExtensionFeature implements StaticFeature {
   fillClientCapabilities(capabilities: any) {
     const textDocument = capabilities.textDocument as TextDocumentClientCapabilities;
     // @ts-ignore: clangd extension
-    textDocument.publishDiagnostics?.categorySupport = true;
-    // @ts-ignore: clangd extension
     textDocument.publishDiagnostics?.codeActionsInline = true;
     // @ts-ignore: clangd extension
     textDocument.completion?.editsNearCursor = true;
@@ -64,15 +62,6 @@ export class Ctx {
       ],
       initializationOptions: { clangdFileStatus: true },
       outputChannel,
-      middleware: {
-        handleDiagnostics: (uri: string, diagnostics: Diagnostic[], next: HandleDiagnosticsSignature) => {
-          for (const diagnostic of diagnostics) {
-            // @ts-ignore
-            diagnostic.source = `${diagnostic.source}(${diagnostic.category})`;
-          }
-          next(uri, diagnostics);
-        }
-      }
     };
 
     const client = new LanguageClient('clangd Language Server', serverOptions, clientOptions);

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -1,6 +1,6 @@
-import { Executable, ExtensionContext, HandleDiagnosticsSignature, LanguageClient, LanguageClientOptions, ServerOptions, services, StaticFeature, workspace } from 'coc.nvim';
+import { Executable, ExtensionContext, LanguageClient, LanguageClientOptions, ServerOptions, services, StaticFeature, workspace } from 'coc.nvim';
 import { existsSync } from 'fs';
-import { Diagnostic, TextDocumentClientCapabilities } from 'vscode-languageserver-protocol';
+import { TextDocumentClientCapabilities } from 'vscode-languageserver-protocol';
 import which from 'which';
 import { Config } from './config';
 
@@ -61,7 +61,7 @@ export class Ctx {
         { scheme: 'file', pattern: cudaFilePattern }
       ],
       initializationOptions: { clangdFileStatus: true },
-      outputChannel,
+      outputChannel
     };
 
     const client = new LanguageClient('clangd Language Server', serverOptions, clientOptions);


### PR DESCRIPTION
This is a nice idea but the categories are not useful enough in practice
to justify showing their fairly verbose names.
Mostly because "Semantic Issue" and "Parse Issue" categories are too large - these are the majority of diagnostics produced in practice. There are some more fine-grained things for ObjC (reflecting that this is basically only surfaced in Apple tools I think) but I this is totally uninformative for C++.

Here's the full list of categories grepped from tablegen files in clang:

```
DiagnosticSerializationKinds.td:let CategoryName = "AST Deserialization Issue" in {
DiagnosticSerializationKinds.td:let CategoryName = "AST Serialization Issue" in {
DiagnosticASTKinds.td:let CategoryName = "Inline Assembly Issue" in {
DiagnosticASTKinds.td:let CategoryName = "VTable ABI Issue" in {
DiagnosticRefactoringKinds.td:let CategoryName = "Refactoring Invocation Issue" in {
DiagnosticFrontendKinds.td:let CategoryName = "Instrumentation Issue" in {
DiagnosticParseKinds.td:let CategoryName = "Inline Assembly Issue" in {
DiagnosticParseKinds.td:let CategoryName = "Parse Issue" in {
DiagnosticParseKinds.td:let CategoryName = "ARC Parse Issue" in {
DiagnosticParseKinds.td:let CategoryName = "Modules Issue" in {
DiagnosticParseKinds.td:let CategoryName = "Generics Issue" in {
DiagnosticParseKinds.td:let CategoryName = "Coroutines Issue" in {
DiagnosticParseKinds.td:let CategoryName = "Concepts Issue" in {
DiagnosticCommonKinds.td:let CategoryName = "Lexical or Preprocessor Issue" in {
DiagnosticCommonKinds.td:let CategoryName = "Parse Issue" in {
DiagnosticCommonKinds.td:let CategoryName = "Nullability Issue" in {
DiagnosticCommonKinds.td:let CategoryName = "Inline Assembly Issue" in {
DiagnosticLexKinds.td:let CategoryName = "User-Defined Issue" in {
DiagnosticLexKinds.td:let CategoryName = "Nullability Issue" in {
DiagnosticLexKinds.td:let CategoryName = "Dependency Directive Source Minimization Issue" in {
DiagnosticCommentKinds.td:let CategoryName = "Documentation Issue" in {
DiagnosticSemaKinds.td:let CategoryName = "Semantic Issue" in {
DiagnosticSemaKinds.td:let CategoryName = "Cocoa API Issue" in {
DiagnosticSemaKinds.td:let CategoryName = "ARC Semantic Issue" in {
DiagnosticSemaKinds.td:let CategoryName = "ARC Weak References" in {
DiagnosticSemaKinds.td:let CategoryName = "ARC Restrictions" in {
DiagnosticSemaKinds.td:let CategoryName = "ARC Retain Cycle" in {
DiagnosticSemaKinds.td:let CategoryName = "ARC and @properties" in {
DiagnosticSemaKinds.td:let CategoryName = "ARC Casting Rules" in {
DiagnosticSemaKinds.td:let CategoryName = "Lambda Issue" in {
DiagnosticSemaKinds.td:let CategoryName = "Inline Assembly Issue" in {
DiagnosticSemaKinds.td:let CategoryName = "Semantic Issue" in {
DiagnosticSemaKinds.td:let CategoryName = "OpenMP Issue" in {
DiagnosticSemaKinds.td:let CategoryName = "Related Result Type Issue" in {
DiagnosticSemaKinds.td:let CategoryName = "Modules Issue" in {
DiagnosticSemaKinds.td:let CategoryName = "Coroutines Issue" in {
DiagnosticSemaKinds.td:let CategoryName = "Documentation Issue" in {
DiagnosticSemaKinds.td:let CategoryName = "Nullability Issue" in {
DiagnosticSemaKinds.td:let CategoryName = "Generics Issue" in {
```