### PR TITLE
feat(diagnostics): don't request code actions inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This extension connects [coc.nvim][] to the [clangd][] language server.
 
 - Switching between header and implementation file: `:CocCommand clangd.switchSourceHeader`
 - File status monitor, shows on NeoVim statusline
-- Requesting fixes along with diagnostics
 - Describe symbol under the cursor: `:CocCommand clangd.symbolInfo`
 - Completions that adjust text near the cursor (e.g. correcting `.` to `->`)
 

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -9,8 +9,6 @@ class ClangdExtensionFeature implements StaticFeature {
   fillClientCapabilities(capabilities: any) {
     const textDocument = capabilities.textDocument as TextDocumentClientCapabilities;
     // @ts-ignore: clangd extension
-    textDocument.publishDiagnostics?.codeActionsInline = true;
-    // @ts-ignore: clangd extension
     textDocument.completion?.editsNearCursor = true;
   }
 }


### PR DESCRIPTION
coc.nvim doesn't use them. I beleive the original motivation was to
display them as part of diagnostic text, but the text already contains
"(fix available)".

@fannheyward was there another reason to keep this around?