### PR TITLE
add semanticHighlighting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,12 @@ This extension connects [coc.nvim][] to the [clangd][] language server.
 
 1. make sure you have [clangd][] installed already, and set up `compile_commands.json` for your project.
 1. install [Node.js][]. `coc.nvim` and `coc-clangd` run on Node.js.
-1. install `coc.nvim`. Instructions using `vim-plug`
-   (check out [coc.nvim Wiki][] other options):
-     - Add to `.vimrc`: `vim Plug 'neoclide/coc.nvim', {'branch': 'release'}`
-     - in vim, run `:PlugInstall`
-1. In vim, run `:CocInstall coc-clangd`
+1. install `coc.nvim`. Instructions using `vim-plug` (check out [coc.nvim Wiki][] other options):
+   - add to `.vimrc`: `vim Plug 'neoclide/coc.nvim', {'branch': 'release'}`
+   - in vim, run `:PlugInstall`
+1. in vim, run `:CocInstall coc-clangd`
 
-> **Note**: If you've configured `clangd` as a languageServer in
-  `coc-settings.json`, you should remove it to avoid running clangd twice!
+> **Note**: If you've configured `clangd` as a languageServer in `coc-settings.json`, you should remove it to avoid running clangd twice!
 
 ## Protocol extensions
 
@@ -33,6 +31,7 @@ This extension connects [coc.nvim][] to the [clangd][] language server.
 - `clangd.enabled`: enable `coc-clangd`, default `true`
 - `clangd.path`: path to `clangd` executable, default `clangd`
 - `clangd.arguments`: arguments for `clangd` server
+- `clangd.semanticHighlighting`: enable semantic highlighting, requires [jackguo380/vim-lsp-cxx-highlight](https://github.com/jackguo380/vim-lsp-cxx-highlight) to work, default `false`
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
         },
         "clangd.semanticHighlighting": {
           "type": "boolean",
-          "default": "true",
-          "description": "Enable semantic highlighting in clangd"
+          "default": "false",
+          "description": "Enable semantic highlighting in clangd, requires jackguo380/vim-lsp-cxx-highlight to work"
         },
         "suggest.detailMaxLength": {
           "type": "number",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
           },
           "description": "Arguments for clangd server"
         },
+        "clangd.semanticHighlighting": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Enable semantic highlighting in clangd"
+        },
         "suggest.detailMaxLength": {
           "type": "number",
           "description": "Max length of detail that should be shown in popup menu.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,4 +17,8 @@ export class Config {
   get arguments() {
     return this.cfg.get<string[]>('arguments', []);
   }
+
+  get semanticHighlighting() {
+    return this.cfg.get('semanticHighlighting', true);
+  }
 }

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -8,8 +8,9 @@ import { SemanticHighlightingFeature } from './semantic-highlighting';
 class ClangdExtensionFeature implements StaticFeature {
   initialize() {}
   fillClientCapabilities(capabilities: any) {
-    const textDocumentCapabilities: TextDocumentClientCapabilities & { completion: { editsNearCursor: boolean } } = capabilities.textDocument;
-    textDocumentCapabilities.completion.editsNearCursor = true;
+    const textDocument = capabilities.textDocument as TextDocumentClientCapabilities;
+    // @ts-ignore: clangd extension
+    textDocument.completion?.editsNearCursor = true;
   }
 }
 

--- a/src/semantic-highlighting.ts
+++ b/src/semantic-highlighting.ts
@@ -1,0 +1,159 @@
+import { BaseLanguageClient, ExtensionContext, State, StaticFeature, workspace } from 'coc.nvim';
+import { ClientCapabilities, NotificationType, Range, ServerCapabilities, TextDocumentClientCapabilities, VersionedTextDocumentIdentifier } from 'vscode-languageserver-protocol';
+
+// Contains the highlighting information for a specified line. Mirrors the
+// structure in the semantic highlighting proposal for LSP.
+interface SemanticHighlightingInformation {
+  // The zero-based line position in the text document.
+  line: number;
+  // A base64 encoded string representing every single highlighted characters
+  // with its start position, length and the "lookup table" index of of the
+  // semantic highlighting Text Mate scopes.
+  tokens: string;
+}
+
+// Parameters for the semantic highlighting (server-side) push notification.
+// Mirrors the structure in the semantic highlighting proposal for LSP.
+interface SemanticHighlightingParams {
+  // The text document that has to be decorated with the semantic highlighting
+  // information.
+  textDocument: VersionedTextDocumentIdentifier;
+  // An array of semantic highlighting information.
+  lines: SemanticHighlightingInformation[];
+}
+
+// A SemanticHighlightingToken decoded from the base64 data sent by clangd.
+interface SemanticHighlightingToken {
+  // Start column for this token.
+  character: number;
+  // Length of the token.
+  length: number;
+  // The TextMate scope index to the clangd scope lookup table.
+  scopeIndex: number;
+  kind: string;
+}
+
+// A line of decoded highlightings from the data clangd sent.
+export interface SemanticHighlightingLine {
+  // The zero-based line position in the text document.
+  line: number;
+  // All SemanticHighlightingTokens on the line.
+  tokens: SemanticHighlightingToken[];
+}
+
+export class SemanticHighlightingFeature implements StaticFeature {
+  private scopeTable: string[][] = [];
+
+  constructor(client: BaseLanguageClient, context: ExtensionContext) {
+    context.subscriptions.push(
+      client.onDidChangeState(({ newState }) => {
+        if (newState === State.Running) {
+          const notification = new NotificationType<SemanticHighlightingParams, void>('textDocument/semanticHighlighting');
+          client.onNotification(notification, this.handleNotification.bind(this));
+        }
+      })
+    );
+  }
+
+  initialize(capabilities: ServerCapabilities) {
+    const serverCapabilities: ServerCapabilities & { semanticHighlighting?: { scopes: string[][] } } = capabilities;
+    if (!serverCapabilities.semanticHighlighting) return;
+
+    this.scopeTable = serverCapabilities.semanticHighlighting.scopes;
+  }
+
+  fillClientCapabilities(capabilities: ClientCapabilities) {
+    const textDocumentCapabilities: TextDocumentClientCapabilities & { semanticHighlightingCapabilities?: { semanticHighlighting: boolean } } = capabilities.textDocument!;
+    textDocumentCapabilities.semanticHighlightingCapabilities = {
+      semanticHighlighting: true,
+    };
+  }
+
+  async handleNotification(params: SemanticHighlightingParams) {
+    // use https://github.com/jackguo380/vim-lsp-cxx-highlight to do highlighting
+    const lines: SemanticHighlightingLine[] = params.lines.map((line) => ({ line: line.line, tokens: this.decodeTokens(line.tokens) }));
+    const symbols: any[] = [];
+
+    for (const line of lines) {
+      for (const token of line.tokens) {
+        symbols.push({
+          id: 0,
+          kind: token.kind,
+          ranges: [Range.create(line.line, token.character, line.line, token.character + token.length)],
+          parentKind: 'Unknown', // FIXME
+          storage: 'None', // FIXME
+        });
+      }
+    }
+
+    const doc = workspace.getDocument(params.textDocument.uri);
+    await workspace.nvim.call('lsp_cxx_hl#hl#notify_symbols', [doc.bufnr, symbols]);
+  }
+
+  // Converts a string of base64 encoded tokens into the corresponding array of SemanticHighlightingToken.
+  private decodeTokens(tokens: string): SemanticHighlightingToken[] {
+    const scopeMask = 0xffff;
+    const lenShift = 0x10;
+    const uint32Size = 4;
+    const buf = Buffer.from(tokens, 'base64');
+    const retTokens: SemanticHighlightingToken[] = [];
+    for (let i = 0, end = buf.length / uint32Size; i < end; i += 2) {
+      const start = buf.readUInt32BE(i * uint32Size);
+      const lenKind = buf.readUInt32BE((i + 1) * uint32Size);
+      const scopeIndex = lenKind & scopeMask;
+      const len = lenKind >>> lenShift;
+      const kind = this.scopeTable[scopeIndex][0];
+      retTokens.push({ character: start, scopeIndex: scopeIndex, length: len, kind: this.decodeKind(kind) });
+    }
+
+    return retTokens;
+  }
+
+  private decodeKind(kind: string) {
+    // https://github.com/llvm/llvm-project/blob/9adc7fc3cdf571bd70d5f8bda4e2e9c233c5fd63/clang-tools-extra/clangd/SemanticHighlighting.cpp#L477
+    switch (kind) {
+      case 'entity.name.function.cpp':
+        return 'Function';
+      case 'entity.name.function.method.cpp':
+        return 'Method';
+      case 'entity.name.function.method.static.cpp':
+        return 'StaticMethod';
+      case 'variable.other.cpp':
+        return 'Variable';
+      case 'variable.other.local.cpp':
+        return 'LocalVariable';
+      case 'variable.parameter.cpp':
+        return 'Parameter';
+      case 'variable.other.field.cpp':
+        return 'Field';
+      case 'variable.other.field.static.cpp':
+        return 'StaticField';
+      case 'entity.name.type.class.cpp':
+        return 'Class';
+      case 'entity.name.type.enum.cpp':
+        return 'Enum';
+      case 'variable.other.enummember.cpp':
+        return 'EnumConstant';
+      case 'entity.name.type.typedef.cpp':
+        return 'Typedef';
+      case 'entity.name.type.dependent.cpp':
+        return 'DependentType';
+      case 'entity.name.other.dependent.cpp':
+        return 'DependentName';
+      case 'entity.name.namespace.cpp':
+        return 'Namespace';
+      case 'entity.name.type.template.cpp':
+        return 'TemplateParameter';
+      case 'entity.name.type.concept.cpp':
+        return 'Concept';
+      case 'storage.type.primitive.cpp':
+        return 'Primitive';
+      case 'entity.name.function.preprocessor.cpp':
+        return 'Macro';
+      case 'meta.disabled':
+        return 'InactiveCode';
+      default:
+        return 'Unknown';
+    }
+  }
+}

--- a/src/semantic-highlighting.ts
+++ b/src/semantic-highlighting.ts
@@ -1,6 +1,8 @@
 import { BaseLanguageClient, ExtensionContext, State, StaticFeature, workspace } from 'coc.nvim';
 import { ClientCapabilities, NotificationType, Range, ServerCapabilities, TextDocumentClientCapabilities, VersionedTextDocumentIdentifier } from 'vscode-languageserver-protocol';
 
+// semanticHighlighting protocol: https://github.com/microsoft/vscode-languageserver-node/pull/367
+//
 // Contains the highlighting information for a specified line. Mirrors the
 // structure in the semantic highlighting proposal for LSP.
 interface SemanticHighlightingInformation {

--- a/src/semantic-highlighting.ts
+++ b/src/semantic-highlighting.ts
@@ -73,20 +73,19 @@ export class SemanticHighlightingFeature implements StaticFeature {
     // use https://github.com/jackguo380/vim-lsp-cxx-highlight to do highlighting
     const lines: SemanticHighlightingLine[] = params.lines.map((line) => ({ line: line.line, tokens: this.decodeTokens(line.tokens) }));
     const symbols: any[] = [];
-    const skipped: any[] = [];
+    const skipped: Range[] = [];
 
     for (const line of lines) {
       for (const token of line.tokens) {
-        symbols.push({
-          id: 0,
-          kind: token.kind,
-          ranges: [Range.create(line.line, token.character, line.line, token.character + token.length)],
-          parentKind: 'Unknown', // FIXME
-          storage: 'None', // FIXME
-        });
         if (token.kind === 'InactiveCode') {
-          skipped.push({
+          skipped.push(Range.create(line.line, token.character, line.line, token.character + token.length));
+        } else {
+          symbols.push({
+            id: 0,
+            kind: token.kind,
             ranges: [Range.create(line.line, token.character, line.line, token.character + token.length)],
+            parentKind: 'Unknown',
+            storage: 'None',
           });
         }
       }


### PR DESCRIPTION
I'm working on `semanticHighlighting` on coc-clangd, here is a demo:

<details><summary>test.cpp</summary>

```cpp
#include <iostream>

class Bar {
public:
  void f();
};

int foo(int x, int y) { return x + y; }

int main(int argc, char *argv[]) {
  Bar bar;
  bar.f();

  return 0;
}
```

</details>

Without semantic highlighting:

<img width="474" alt="Screen Shot 2020-03-23 at 22 55 31" src="https://user-images.githubusercontent.com/345274/77329841-8212ab80-6d59-11ea-9b30-7580527fda65.png">

With semantic highlighting + [vim-lsp-cxx-highlight][]
<img width="478" alt="Screen Shot 2020-03-23 at 22 56 09" src="https://user-images.githubusercontent.com/345274/77329904-98b90280-6d59-11ea-8db2-dc7d496c0147.png">

Still needs some improvement: currently, I just parse semantic tokens from clangd to [vim-lsp-cxx-highlight][]'s symbol format, then call `lsp_cxx_hl#hl#notify_symbols` to do highlight. For example, `clangd`'s token:

```
{
  line: 11,
  tokens: [
    { character: 6, scopeIndex: 2, length: 1 }
  ]
}
```

to

```
{
    id: 0,
    kind: 'Method',
    ranges: [ start: { line: 11, character: 6 }, end: { line: 11, character: 7 } ],
    parentKind: 'Unknown',
    storage: 'None'
  }
```

But I can't get `id`, `storage` and `parentKind` from clangd's token, I just set to `Unknown` and None. Anyone can help me to correct the token format?

[vim-lsp-cxx-highlight]: https://github.com/jackguo380/vim-lsp-cxx-highlight