### PR TITLE
feat(ctx): support filetype objc & objcpp

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "onLanguage:c",
     "onLanguage:cpp",
     "onLanguage:cuda",
+    "onLanguage:objc",
+    "onLanguage:objcpp",
     "onLanguage:arduino",
     "onLanguage:objective-c",
     "onLanguage:objective-cpp",

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -40,6 +40,8 @@ export class Ctx {
       documentSelector: [
         { scheme: 'file', language: 'c' },
         { scheme: 'file', language: 'cpp' },
+        { scheme: 'file', language: 'objc' },
+        { scheme: 'file', language: 'objcpp' },
         { scheme: 'file', language: 'objective-c' },
         { scheme: 'file', language: 'objective-cpp' },
         { scheme: 'file', pattern: cudaFilePattern },


### PR DESCRIPTION
Reference to official vim repo, filetype is `objc` and `objcpp`
 - https://github.com/vim/vim/blob/master/runtime/syntax/objc.vim
 - https://github.com/vim/vim/blob/master/runtime/syntax/objcpp.vim
