### PR TITLE
Disable config file watcher if a hot-reload server capability is set

### DIFF
--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -21,7 +21,7 @@ export class Ctx {
     this.config = new Config();
   }
 
-  async startServer(bin: string) {
+  async startServer(bin: string, ...features: StaticFeature[]) {
     const old = this.client;
     if (old) {
       await old.stop();
@@ -103,6 +103,7 @@ export class Ctx {
         client.registerFeature(new SemanticHighlightingFeature(client, this.context));
       }
     }
+    for (const feature of features) client.registerFeature(feature);
     this.context.subscriptions.push(services.registLanguageClient(client));
     await client.onReady();
 

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -1,0 +1,48 @@
+import { StaticFeature, workspace } from 'coc.nvim';
+import { ServerCapabilities } from 'vscode-languageserver-protocol';
+import { basename } from 'path';
+import { Ctx } from './ctx';
+
+interface ClangdClientCapabilities {
+  compilationDatabase?: { automaticReload?: boolean };
+}
+
+// FIXME: remove this feature once clangd 12 is old enough to assume that
+// server-side reload is always supported.
+export class ReloadFeature implements StaticFeature {
+  constructor(private ctx: Ctx, private activate: () => void) {}
+  initialize(caps: ServerCapabilities) {
+    // Don't restart the server if it's able to reload config files itself.
+    if ((caps as ClangdClientCapabilities).compilationDatabase?.automaticReload) {
+      return;
+    }
+
+    const fileWatcher = workspace.createFileSystemWatcher('**/{compile_commands.json,compile_flags.txt}');
+    this.ctx.subscriptions.push(
+      fileWatcher,
+      fileWatcher.onDidChange((e) => this.reload(e.fsPath)),
+      fileWatcher.onDidCreate((e) => this.reload(e.fsPath))
+    );
+  }
+
+  fillClientCapabilities() {}
+
+  async reload(url: string) {
+    const notification = this.ctx.config.showDBChangedNotification;
+    if (notification) {
+      const msg = `${basename(url)} has changed, clangd is reloading...`;
+      workspace.showMessage(msg);
+    }
+
+    for (const sub of this.ctx.subscriptions) {
+      try {
+        sub.dispose();
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    this.activate();
+    if (notification) workspace.showMessage(`clangd has reloaded`);
+  }
+}


### PR DESCRIPTION
Corresponds to https://reviews.llvm.org/D94222

Required complicating the code a bit as we need to do this conditional on ServerCapabilities, which in turn requires using a Feature. Moved it out into a separate file accordingly.

I've tested this locally with clangd with/without the capability.