### PR TITLE
Add support for .clangd as configuration root

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,13 +44,15 @@
     "onLanguage:objective-c",
     "onLanguage:objective-cpp",
     "workspaceContains:**/compile_commands.json",
-    "workspaceContains:**/compile_flags.txt"
+    "workspaceContains:**/compile_flags.txt",
+    "workspaceContains:**/.clangd"
   ],
   "rootPatterns": [
     {
       "patterns": [
         "compile_commands.json",
-        "compile_flags.txt"
+        "compile_flags.txt",
+        ".clangd"
       ]
     }
   ],

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -18,7 +18,7 @@ export class ReloadFeature implements StaticFeature {
       return;
     }
 
-    const fileWatcher = workspace.createFileSystemWatcher('**/{compile_commands.json,compile_flags.txt}');
+    const fileWatcher = workspace.createFileSystemWatcher('**/{compile_commands.json,compile_flags.txt,.clangd}');
     this.ctx.subscriptions.push(
       fileWatcher,
       fileWatcher.onDidChange((e) => this.reload(e.fsPath)),


### PR DESCRIPTION
clangd 11 added new YAML configuration format through the `.clangd`
configuration file. coc-clangd still doesn't support it, so, adding it.
