### PR TITLE
Add candidate directories for compile databases.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+# Unix-style newlines with a newline ending every file
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+end_of_line = lf
+charset = utf-8
+
+indent_style = space
+indent_size = 2

--- a/package.json
+++ b/package.json
@@ -86,6 +86,11 @@
           "default": "",
           "description": "Specifies the directory containing the compilation database"
         },
+        "clangd.compilationDatabaseCandidates": {
+          "type": "array",
+          "default": [],
+          "description": "Specifies the directories that may contain a compilation database"
+        },
         "clangd.path": {
           "type": "string",
           "default": "",

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,10 @@ export class Config {
     return this.cfg.get<string>('compilationDatabasePath');
   }
 
+  get compilationDatabaseCandidates() {
+    return this.cfg.get<string[]>('compilationDatabaseCandidates');
+  }
+
   get serverCompletionRanking() {
     return this.cfg.get('serverCompletionRanking') as boolean;
   }

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -15,6 +15,7 @@ import {
   workspace,
 } from 'coc.nvim';
 import { Config } from './config';
+import { closestCompilationDatabase } from './database-and-flags';
 
 export class ClangdExtensionFeature implements StaticFeature {
   constructor() {}
@@ -70,6 +71,12 @@ export class Ctx {
     const initializationOptions: any = { clangdFileStatus: true, fallbackFlags: this.config.fallbackFlags };
     if (this.config.compilationDatabasePath) {
       initializationOptions.compilationDatabasePath = this.config.compilationDatabasePath;
+    }
+    else if (this.config.compilationDatabaseCandidates) {
+      const db_path = closestCompilationDatabase(workspace.cwd , this.config.compilationDatabaseCandidates);
+      if(db_path) {
+        initializationOptions.compilationDatabasePath = db_path;
+      }
     }
 
     const disabledFeatures: string[] = [];

--- a/src/database-and-flags.ts
+++ b/src/database-and-flags.ts
@@ -1,0 +1,30 @@
+import { workspace as coc_workspace } from 'coc.nvim';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export function closestCompilationDatabase(workspace: string, candidates: string[]): string {
+  // If the workspace does not exists we just return '' which is invalid.
+  // In this case `clangd` will ignore the option and try other means to find the db.
+  if (!fs.existsSync(workspace)) return '';
+
+  // Expand paths to be fully qualified. Also expands environment variables
+  // and ${CWD} to the *C*urrent *W*orkspace *D*irectory (see workspace.expand).
+  // NOTE: This is even better than the current working directory, because you
+  // can start vim in a subdirectory of your project and still get working completion.
+  const expand = (item: string): string => {
+    return coc_workspace.expand(item.replace('${CWD}', workspace));
+  };
+  const expandend_candiates = candidates.map(expand);
+
+  // Return the first (sorting matters!) candidate directory that contains a
+  // compilation database. Otherwise return the empty string.
+  let rv = '';
+  for(const candidate of expandend_candiates) {
+    if(fs.existsSync(candidate + path.sep + 'compile_commands.json')) {
+      rv = candidate;
+      break;
+    }
+  }
+
+  return rv;
+}


### PR DESCRIPTION
Hi,

this is a first try to add a feature in a new language. I will add documentation once the feature itself is ready generally accepted by you. I think the plugin is now able to find and use a compilation database . It would nice if you cold give me some advice what I need to do to get this feature accepted.

This is how I use this feature:
`"clangd.compilationDatabaseCandidates": ["${CWD}-build/current", "${CWD}-build" ,"${CWD}/build"],`
It allows me to have source and build directories as siblings.

My setup usually looks like this:
- `path/to/project` (source dir)
- `path/to/project-build/Debug` (debug build)
- `path/to/project-build/Release` (release build)
- `path/to/project-build/Tsan` (Tsan build)
- `path/to/project-build/current` (symlink to currently selected build)

I really like to have the build outside of the source. It has the advantage that you can have different builds at the same time and switching configurations takes significantly less time. Furthermore `git clean` does not delete required symlinks and other tools do not get confused by build artifacts.