### PR TITLE
Use coc.nvim render inlay hints

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/which": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
-    "coc.nvim": "^0.0.83-next.9",
+    "coc.nvim": "^0.0.83-next.17",
     "esbuild": "^0.16.14",
     "eslint": "^8.0.1",
     "fs-jetpack": "^5.0.0",

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -12,6 +12,7 @@ import {
   ServerOptions,
   services,
   StaticFeature,
+  TextEdit,
   workspace,
 } from 'coc.nvim';
 import { existsSync } from 'fs';
@@ -30,7 +31,7 @@ export class ClangdExtensionFeature implements StaticFeature {
   }
 }
 
-const documentSelector: DocumentSelector = [
+export const documentSelector: DocumentSelector = [
   { scheme: 'file', language: 'c' },
   { scheme: 'file', language: 'cpp' },
   { scheme: 'file', language: 'objc' },
@@ -125,7 +126,7 @@ export class Ctx {
               const { textEdit } = item;
               const { newText } = textEdit;
               if (item.kind === CompletionItemKind.Function || (item.kind === CompletionItemKind.Text && newText.slice(-1) === ')')) {
-                item.textEdit = { range: textEdit.range, newText: newText + ';' };
+                item.textEdit = { range: (textEdit as TextEdit).range, newText: newText + ';' };
               }
             }
           }

--- a/src/inlay-hints.ts
+++ b/src/inlay-hints.ts
@@ -1,170 +1,83 @@
-import { CancellationTokenSource, Disposable, Document, events, Position, Range, RequestType, StaticFeature, TextDocumentIdentifier, workspace } from 'coc.nvim';
+import { Range, Position, TextDocumentIdentifier, RequestType, StaticFeature, DocumentSelector, languages, FeatureState, InlayHintsProvider, InlayHintKind, InlayHint, LinesTextDocument, CancellationToken } from 'coc.nvim';
 import { ServerCapabilities } from 'vscode-languageserver-protocol';
-import { Ctx } from './ctx';
 
-/// Protocol ///
+import { Ctx, documentSelector } from './ctx';
 
-enum InlayHintKind {
-  Parameter = 'parameter',
-  Type = 'type',
-}
+namespace protocol {
 
-interface InlayHint {
-  range: Range;
-  position: Position; // omitted by old servers, see hintSide.
-  kind: InlayHintKind | string;
-  label: string;
-}
+  export interface InlayHint {
+    range: Range;
+    position?: Position; // omitted by old servers, see hintSide.
+    kind: string;
+    label: string;
+  }
 
-interface InlaysDecorations {
-  type: InlayHint[];
-  parameter: InlayHint[];
-}
+  export interface InlayHintsParams {
+    textDocument: TextDocumentIdentifier;
+    range?: Range;
+  }
 
-interface InlayHintsParams {
-  textDocument: TextDocumentIdentifier;
-}
+  export namespace InlayHintsRequest {
+    export const type =
+      new RequestType<InlayHintsParams, InlayHint[], void>(
+        'clangd/inlayHints');
+  }
 
-namespace InlayHintsRequest {
-  export const type = new RequestType<InlayHintsParams, InlayHint[], void>('clangd/inlayHints');
-}
-
-/// Feature state and triggering. ///
-
-interface ClangSourceFile {
-  uri: string;
-  inlaysRequest: CancellationTokenSource | null;
-}
+} // namespace protocol
 
 export class InlayHintsFeature implements StaticFeature {
-  private namespace = 0;
-  private sourceFiles = new Map<string, ClangSourceFile>(); // keys are URIs
-  private readonly disposables: Disposable[] = [];
 
-  constructor(private readonly ctx: Ctx) {}
+  constructor(private readonly context: Ctx) {}
 
   fillClientCapabilities() {}
   fillInitializeParams() {}
 
-  async initialize(capabilities: ServerCapabilities) {
-    this.namespace = await workspace.nvim.createNamespace('clangdInlayHints');
-
-    const serverCapabilities: ServerCapabilities & { clangdInlayHintsProvider?: boolean } = capabilities;
-    if (!serverCapabilities.clangdInlayHintsProvider || serverCapabilities.inlayHintProvider || !this.ctx.config.inlayHints.enable) {
+  initialize(capabilities: ServerCapabilities,
+    _documentSelector: DocumentSelector | undefined) {
+    const serverCapabilities: ServerCapabilities &
+    { clangdInlayHintsProvider?: boolean, inlayHintProvider?: any; } =
+      capabilities;
+    // If the clangd server supports LSP 3.17 inlay hints, these are handled by
+    // the vscode-languageclient library - don't send custom requests too!
+    if (!serverCapabilities.clangdInlayHintsProvider ||
+      serverCapabilities.inlayHintProvider)
       return;
-    }
+    this.context.subscriptions.push(languages.registerInlayHintsProvider(
+      documentSelector, new Provider(this.context)));
+  }
+  getState(): FeatureState { return { kind: 'static' }; }
+  dispose() {}
+}
 
-    events.on('InsertLeave', async (bufnr) => await this.syncAndRenderHints(workspace.getDocument(bufnr)));
+class Provider implements InlayHintsProvider {
+  constructor(private context: Ctx) {}
 
-    workspace.onDidChangeTextDocument(
-      async (e) => {
-        if (events.insertMode) return;
-        await this.syncAndRenderHints(workspace.getDocument(e.bufnr));
-      },
-      this,
-      this.disposables
-    );
-
-    workspace.onDidOpenTextDocument(
-      async (e) => {
-        await this.syncAndRenderHints(workspace.getDocument(e.bufnr));
-      },
-      this,
-      this.disposables
-    );
-
-    const current = await workspace.document;
-    await this.syncAndRenderHints(current);
+  decodeKind(kind: string): InlayHintKind | undefined {
+    if (kind == 'type')
+      return InlayHintKind.Type;
+    if (kind == 'parameter')
+      return InlayHintKind.Parameter;
+    return undefined;
   }
 
-  dispose() {
-    this.sourceFiles.forEach((file) => file.inlaysRequest?.cancel());
-    this.disposables.forEach((d) => d.dispose());
+  decode(hint: protocol.InlayHint): InlayHint {
+    return {
+      position: hint.position ?? hint.range.start,
+      kind: this.decodeKind(hint.kind),
+      label: hint.label.trim(),
+      paddingLeft: hint.label.startsWith(' '),
+      paddingRight: hint.label.endsWith(' '),
+    };
   }
 
-  private renderHints(doc: Document, hints: InlayHint[]) {
-    const decorations: InlaysDecorations = {
-      parameter: [],
-      type: [],
+  async provideInlayHints(document: LinesTextDocument, range: Range, token: CancellationToken): Promise<InlayHint[]> {
+    const request: protocol.InlayHintsParams = {
+      textDocument: { uri: document.uri },
+      range
     };
 
-    for (const hint of hints) {
-      switch (hint.kind) {
-        case InlayHintKind.Parameter || 'parameter':
-          decorations.parameter.push(hint);
-          break;
-        case InlayHintKind.Type || 'type':
-          decorations.type.push(hint);
-          break;
-        default:
-          continue;
-      }
-    }
-
-    doc.buffer.clearNamespace(this.namespace);
-
-    const inlayHints = {};
-    const sep = this.ctx.config.inlayHints.sep;
-    for (const hint of decorations.parameter) {
-      if (!hint.label.length) continue;
-      const start = hint.range.start.character;
-      const end = hint.range.end.character;
-      const line = doc.getline(hint.range.start.line);
-      const symbol = `${line.substring(start, end)}`;
-      const chunks: [[string, string]] = [[`${sep}${hint.label}${symbol}`, 'CocHintVirtualText']];
-      if (inlayHints[hint.position.line] === undefined) {
-        inlayHints[hint.position.line] = chunks;
-      } else {
-        inlayHints[hint.position.line].push([' ', 'Normal']);
-        inlayHints[hint.position.line].push(chunks[0]);
-      }
-    }
-
-    for (const hint of decorations.type) {
-      if (!hint.label.length) continue;
-      const chunks: [[string, string]] = [[`${sep}${hint.label}`, 'CocHintVirtualText']];
-      if (inlayHints[hint.position.line] === undefined) {
-        inlayHints[hint.position.line] = chunks;
-      } else {
-        inlayHints[hint.position.line].push([' ', 'Normal']);
-        inlayHints[hint.position.line].push(chunks[0]);
-      }
-    }
-
-    Object.keys(inlayHints).forEach((line) => {
-      if (workspace.has('nvim-0.6.0')) {
-        doc.buffer.setExtMark(this.namespace, Number(line), 0, { virt_text_pos: 'eol', hl_mode: 'combine', virt_text: inlayHints[line] });
-      } else {
-        doc.buffer.setVirtualText(this.namespace, Number(line), inlayHints[line], {});
-      }
-    });
-  }
-
-  private async syncAndRenderHints(doc: Document) {
-    if (!doc) return;
-    if (!this.ctx.config.inlayHints.enable) return;
-    if (!this.ctx.isClangDocument(doc.textDocument)) return;
-
-    const uri = doc.uri.toString();
-    const file = this.sourceFiles.get(uri) || { uri, inlaysRequest: null };
-
-    this.fetchHints(uri, file).then(async (hints) => {
-      if (!hints) return;
-
-      this.renderHints(doc, hints);
-    });
-  }
-
-  private async fetchHints(uri: string, file: ClangSourceFile): Promise<InlayHint[] | null> {
-    file.inlaysRequest?.cancel();
-
-    const tokenSource = new CancellationTokenSource();
-    file.inlaysRequest = tokenSource;
-
-    const param = { textDocument: { uri } };
-
-    return this.ctx.client!.sendRequest(InlayHintsRequest.type, param, tokenSource.token).then(res => res, err => {
-      return this.ctx.client!.handleFailedRequest({ kind: InlayHintsRequest.type.method }, tokenSource.token, err, null);
-    });
+    const result = await this.context.client!.sendRequest(
+      protocol.InlayHintsRequest.type, request, token);
+    return result.map(this.decode, this);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -441,10 +441,10 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-coc.nvim@^0.0.83-next.9:
-  version "0.0.83-next.9"
-  resolved "https://registry.yarnpkg.com/coc.nvim/-/coc.nvim-0.0.83-next.9.tgz#8f7de8c98fa37019286852d3b7229fb91517ab83"
-  integrity sha512-ek5+EgA9N92/6Wt07TAYpavmBgXZto4Dmwmm56oyBl/w4wy3Tod7LfpCp4k9M4xCxhxPtrflIcxvhdDUPIeMuw==
+coc.nvim@^0.0.83-next.17:
+  version "0.0.83-next.17"
+  resolved "https://registry.yarnpkg.com/coc.nvim/-/coc.nvim-0.0.83-next.17.tgz#a1c4baa10927886366241ca0fd3acc7c941a5546"
+  integrity sha512-VjGnxjbvBOboddNQMI5rZnS0HS0tdft9pbnwste5CncPNJaxfz5wEdWd7eFtifukE8STdLltPMNsoO0vul5r/A==
 
 color-convert@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
The same as vscode-clangd.

Inlay hints would be rendered as expected on vim9, and can be configured by language scoped configuration.