### PR TITLE
fix: resolve compile_commands.json symlink to real path for per-build .cache isolation

### DIFF
--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -1,5 +1,5 @@
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, realpathSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import {
   CompletionItemKind,
   type Disposable,
@@ -170,8 +170,10 @@ export class Ctx {
     // Return the first (sorting matters!) candidate directory that contains a
     // compilation database. Otherwise return the empty string.
     for (const candidate of expandendCandidates) {
-      if (existsSync(join(candidate, 'compile_commands.json'))) {
-        return candidate;
+      const compileCommandsPath = join(candidate, 'compile_commands.json');
+      if (existsSync(compileCommandsPath)) {
+        const realPath = realpathSync(compileCommandsPath);
+        return dirname(realPath);
       }
     }
 

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -172,8 +172,12 @@ export class Ctx {
     for (const candidate of expandendCandidates) {
       const compileCommandsPath = join(candidate, 'compile_commands.json');
       if (existsSync(compileCommandsPath)) {
-        const realPath = realpathSync(compileCommandsPath);
-        return dirname(realPath);
+        try {
+          const realPath = realpathSync(compileCommandsPath);
+          return dirname(realPath);
+        } catch {
+          return dirname(compileCommandsPath);
+        }
       }
     }
 


### PR DESCRIPTION
### Problem

Currently, when `compile_commands.json` is a symlink, `closestCompilationDatabase()` returns the directory containing the symlink itself. This causes clangd to create its `.cache` directory at the symlink location, which leads to two issues:

1. **Cache collision** — multiple build configurations (Debug, Release, cross-compile targets) end up sharing a single `.cache`, causing index corruption and confusing diagnostics.
2. **No real isolation** — switching between build configs requires a full reindex, negating the benefit of keeping separate build directories.

### Solution

Use `realpathSync` to resolve the symlink before determining the compilation database path. clangd then creates `.cache` alongside the actual `compile_commands.json`, giving each build configuration its own isolated index.

### Typical workflow this enables

```text
project/
├── build/
│   ├── Debug/
│   │   ├── .cache/              ← clangd index for Debug
│   │   └── compile_commands.json
│   ├── Release/
│   │   ├── .cache/              ← clangd index for Release
│   │   └── compile_commands.json
│   ├── linux-arm64/
│   │   ├── .cache/
│   │   └── compile_commands.json
│   └── ...
└── compile_commands.json -> build/Debug/compile_commands.json
```

Configure:

```jsonc
// .vim/coc-settings.json
{
  "clangd.compilationDatabaseCandidates": ["${workspaceFolder}"]
}
```

To switch build configurations, just change the symlink target:

```bash
ln -sf build/Release/compile_commands.json compile_commands.json
```

No reindexing needed — each configuration keeps its own `.cache`.

### Changes

- `src/ctx.ts` — in `closestCompilationDatabase()`, resolve `compile_commands.json` via `realpathSync` and return its actual parent directory instead of the symlink parent.

### Backward Compatibility

- If `compile_commands.json` is a regular file (not a symlink), `realpathSync` resolves to the same path, so behavior is unchanged.
- Existing `clangd.compilationDatabasePath` users are unaffected — this only applies to `compilationDatabaseCandidates`.